### PR TITLE
OptimizerのUpdateCountがdouble型になっている

### DIFF
--- a/KelpNet/Optimizer.cs
+++ b/KelpNet/Optimizer.cs
@@ -8,7 +8,7 @@ namespace KelpNet
     public abstract class Optimizer
     {
         //更新回数のカウント
-        protected double UpdateCount = 1;
+        protected long UpdateCount = 1;
         protected List<OptimizeParameter> Parameters = new List<OptimizeParameter>();
 
         //更新回数のカウントを取りつつ更新処理を呼び出す


### PR DESCRIPTION
OptimizerのUpdateCountは1づつインクリメントされるので、longの方が適切だと思います。
この値はAdam.csでmath.pow関数の第二引数から参照されていました。
引数はdouble型ですが、問題になることはないと思います。