### PR TITLE
ShapeToArrayLength関数のアクセス修飾子をprivateに変更

### DIFF
--- a/KelpNet/Common/NdArray.cs
+++ b/KelpNet/Common/NdArray.cs
@@ -84,7 +84,7 @@ namespace KelpNet.Common
             return new NdArray(resutlArray, shape);
         }
 
-        static int ShapeToArrayLength(params int[] shapes)
+        private static int ShapeToArrayLength(params int[] shapes)
         {
             int result = 1;
 


### PR DESCRIPTION
他の個所から呼び出されてないようなので、privateにしました。