### PR TITLE
不要なToArrayによる型変換がある

### DIFF
--- a/KelpNet/Functions/Connections/Linear.cs
+++ b/KelpNet/Functions/Connections/Linear.cs
@@ -47,7 +47,7 @@ namespace KelpNet.Functions.Connections
         protected override NdArray NeedPreviousForward(NdArray x)
         {
             //バイアスを最初から入れておく
-            double[] output = this.b.Data.ToArray();
+            double[] output = this.b.Data;
 
             for (int i = 0; i < this.OutputCount; i++)
             {


### PR DESCRIPTION
NeedPreviousForwardのb.Dataはdouble[]であるので、型変換は不要だと思います。