### PR TITLE
Forward関数内の配列を省略できます。

### DIFF
--- a/KelpNet/FunctionStack.cs
+++ b/KelpNet/FunctionStack.cs
@@ -47,15 +47,15 @@ namespace KelpNet
         //Forward
         public override NdArray[] Forward(NdArray[] input)
         {
-            NdArray[][] inputData = new NdArray[this.Functions.Length + 1][];
-            inputData[0] = input;
+            
+            NdArray[] input_ptr = input;
 
             for (int i = 0; i < this.Functions.Length; i++)
             {
-                inputData[i + 1] = this.Functions[i].Forward(inputData[i]);
+                input_ptr = this.Functions[i].Forward(input_ptr);
             }
 
-            return inputData[this.Functions.Length];
+            return input_ptr;
         }
 
         //Backward
@@ -69,19 +69,17 @@ namespace KelpNet
             return backwardResult;
         }
 
-
         //Forward
         public override NdArray Forward(NdArray input)
         {
-            NdArray[] inputData = new NdArray[this.Functions.Length + 1];
-            inputData[0] = input;
+            NdArray input_ptr = input;
 
             for (int i = 0; i < this.Functions.Length; i++)
             {
-                inputData[i + 1] = this.Functions[i].Forward(inputData[i]);
+                input_ptr = this.Functions[i].Forward(input_ptr);
             }
 
-            return inputData[this.Functions.Length];
+            return input_ptr;
         }
 
         //Backward


### PR DESCRIPTION
配列を使わずに同一な処理ができそうなので修正しました。
前回のバージョンでは同じような処理になっていたので、巻き戻しのミスかもしれません。