### PR TITLE
連続空白の扱いが怪しい？

### DIFF
--- a/VocabularyMaker/Vocabulary.cs
+++ b/VocabularyMaker/Vocabulary.cs
@@ -21,7 +21,7 @@ namespace VocabularyMaker
             string strText = sr.ReadToEnd();
             sr.Close();
 
-            string[] replace = strText.Replace("\n", "<EOS>").Trim().Split();
+            string[] replace = strText.Replace("\r\n", "<EOS>").Trim().Split(' ');
 
             //ダブリを除いて辞書に追加
             this.Data.AddRange(replace);


### PR DESCRIPTION
Splitの引数を省略すると、連続空白や制御文字＋空白が空文字列として辞書に登録される場合がありました。