### PR TITLE
Fix path of Resource.resx

### DIFF
--- a/KelpNet/Properties/Resources.resx
+++ b/KelpNet/Properties/Resources.resx
@@ -119,33 +119,33 @@
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="Activation" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\opencl\activations\activation.cl;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>..\OpenCL\Activations\Activation.cl;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="Convolution2D" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\opencl\connections\convolution2d.cl;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>..\OpenCL\Connections\Convolution2D.cl;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="Deconvolution2D" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\opencl\connections\deconvolution2d.cl;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>..\OpenCL\Connections\Deconvolution2D.cl;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="Dropout" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\opencl\noise\dropout.cl;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>..\OpenCL\Noise\Dropout.cl;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="LeakyReLU" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\opencl\activations\leakyrelu.cl;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>..\OpenCL\Activations\LeakyReLU.cl;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="Linear" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\opencl\connections\linear.cl;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>..\OpenCL\Connections\Linear.cl;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="MaxPooling" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\opencl\poolings\maxpooling.cl;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>..\OpenCL\Poolings\MaxPooling.cl;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="ReLU" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\opencl\activations\relu.cl;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>..\OpenCL\Activations\ReLU.cl;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="Sigmoid" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\opencl\activations\sigmoid.cl;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>..\OpenCL\Activations\Sigmoid.cl;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="Tanh" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\opencl\activations\tanh.cl;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>..\OpenCL\Activations\Tanh.cl;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
 </root>


### PR DESCRIPTION
Resource.resxファイルのパスが小文字に統一されていたものを、大文字小文字を区別するように変更